### PR TITLE
Eliminate safe_get! in favor of PaddedViews

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ script:
               user_regs = joinpath(DEPOT_PATH[1],"registries");
               mkpath(user_regs);
               all_registries = Dict("General" => "https://github.com/JuliaRegistries/General.git",
-                            "HolyLabRegistry" => "git@github.com:HolyLab/HolyLabRegistry.git");
+                            "HolyLabRegistry" => "https://github.com/HolyLab/HolyLabRegistry.git");
               Base.shred!(LibGit2.CachedCredentials()) do creds
                 for (reg, url) in all_registries
                   path = joinpath(user_regs, reg);


### PR DESCRIPTION
The only addition is `shiftrange` but that will be needed by an upcoming RegisterMismatch PR.