### PR TITLE
Clean up the dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,24 +3,17 @@ language: julia
 os:
   - linux
 julia:
-  - 0.7
-  - 1.0
+  - 1.1
+  - 1
+  - nightly
 notifications:
   email: false
+
 script:
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
-  - julia -e 'using Pkg, LibGit2;
-              user_regs = joinpath(DEPOT_PATH[1],"registries");
-              mkpath(user_regs);
-              all_registries = Dict("General" => "https://github.com/JuliaRegistries/General.git",
-                            "HolyLabRegistry" => "https://github.com/HolyLab/HolyLabRegistry.git");
-              Base.shred!(LibGit2.CachedCredentials()) do creds
-                for (reg, url) in all_registries
-                  path = joinpath(user_regs, reg);
-                  LibGit2.with(Pkg.GitTools.clone(url, path; header = "registry $reg from $(repr(url))", credentials = creds)) do repo end
-                end
-              end'
-  - julia -e 'using Pkg; Pkg.build(); Pkg.test("RegisterMismatchCommon"; coverage=false)'
+  - julia -e 'using Pkg; pkg"registry add General https://github.com/HolyLab/HolyLabRegistry.git"'
+  - julia -e 'using Pkg; Pkg.build(); Pkg.test(;coverage=true)'
+
 after_success:
 # update the documentation
   - julia -e 'using Pkg; Pkg.add("Documenter")'

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegisterMismatchCommon"
 uuid = "abb2e897-52bf-5d28-a379-6ca321e3b878"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 CenterIndexedArrays = "46a7138f-0d70-54e1-8ada-fb8296f91f24"
@@ -9,9 +9,10 @@ ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 RegisterCore = "67712758-55e7-5c3c-8e85-dda1d7758434"
 
 [compat]
-CenterIndexedArrays = "0.1, 0.2"
+CenterIndexedArrays = "0.2"
 ImageCore = "0.8.1"
 RegisterCore = "0.2"
+julia = "1.1"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/Project.toml
+++ b/Project.toml
@@ -5,8 +5,13 @@ version = "0.2.0"
 
 [deps]
 CenterIndexedArrays = "46a7138f-0d70-54e1-8ada-fb8296f91f24"
+ImageCore = "a09fc81d-aa75-5fe9-8630-4744c3626534"
 RegisterCore = "67712758-55e7-5c3c-8e85-dda1d7758434"
-Images = "916415d5-f1e6-5110-898d-aaa5f9f070e0"
+
+[compat]
+CenterIndexedArrays = "0.1, 0.2"
+ImageCore = "0.8.1"
+RegisterCore = "0.2"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/RegisterMismatchCommon.jl
+++ b/src/RegisterMismatchCommon.jl
@@ -1,6 +1,6 @@
 module RegisterMismatchCommon
 
-using RegisterCore, CenterIndexedArrays, Images
+using RegisterCore, CenterIndexedArrays, ImageCore
 
 export correctbias!, nanpad, mismatch0, aperture_grid, allocate_mmarrays, default_aperture_width, truncatenoise!
 export DimsLike, WidthLike, each_point, aperture_range, assertsamesize, tovec, mismatch, padsize, set_FFTPROD

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,2 +1,4 @@
 using Test
 import RegisterMismatchCommon
+
+# Tests are in RegisterMismatch and RegisterMismatchCuda


### PR DESCRIPTION
This release will essentially provide a way for packages with no explicit dependency on CenterIndexedArrays to require v0.2.0 of that package.