### PR TITLE
Rename current release as version 0.2.2

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "RegisterMismatchCommon"
 uuid = "abb2e897-52bf-5d28-a379-6ca321e3b878"
 authors = ["Tim Holy <tim.holy@gmail.com>"]
-version = "0.2.1"
+version = "0.2.2"
 
 [deps]
 CenterIndexedArrays = "46a7138f-0d70-54e1-8ada-fb8296f91f24"


### PR DESCRIPTION
It turns out there was a previous release called 0.2.1 (presumably based on #2) in HolyLabRegistry, but the Project.toml file here did not get updated. Consequently I called PR #3 "v0.2.1", and when I made a new release it overwrote the old one. This seems to be the cause of
https://discourse.julialang.org/t/how-can-i-register-align-shifted-image-stacks/29244/32?u=tim.holy

This renames the current release 0.2.2. I also pushed a new branch called release-0.2.1 that should fix the 0.2.1 release; that branch should be kept in perpetuity.

Hopefully this won't happen anymore now that we have LocalRegistry.jl.