### PR TITLE
Add support to TagBot.yml for triggering by HolyLabRegistry 

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -1,16 +1,16 @@
 name: TagBot
 on:
-  issue_comment:
-    types:
-      - created
+  repository_dispatch:
   workflow_dispatch:
 jobs:
   TagBot:
-    if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
     runs-on: ubuntu-latest
     steps:
+      - name: Event Information
+        run: |
+          echo "Event '${{ github.event.action }}' received from '${{ github.event.client_payload.repository }}'"
       - uses: JuliaRegistries/TagBot@v1
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          ssh: ${{ secrets.DOCUMENTER_KEY }}
+          token: ${{ secrets.DOCUMENTER_KEY }}
           registry: HolyLab/HolyLabRegistry
+          lookback: 300


### PR DESCRIPTION
Updates tagbot to be triggered by new releases to the registry.

Paired with https://github.com/HolyLab/HolyLabRegistry/pull/161